### PR TITLE
Lower the Pyraminx filtering limit to 6 moves.

### DIFF
--- a/scrambles/src/puzzle/PyraminxPuzzle.java
+++ b/scrambles/src/puzzle/PyraminxPuzzle.java
@@ -34,7 +34,7 @@ public class PyraminxPuzzle extends Puzzle {
 
     public PyraminxPuzzle() {
         pyraminxSolver = new PyraminxSolver();
-        wcaMinScrambleDistance = 7;
+        wcaMinScrambleDistance = 6;
     }
 
     @Override


### PR DESCRIPTION
This matches the official-2015-07-01 Regulations.
Fixes issue #193.