### PR TITLE
Make HTTP server set headers for not caching files. Fixes #215

### DIFF
--- a/tnoodlejs/tmtproject.py
+++ b/tnoodlejs/tmtproject.py
@@ -87,7 +87,7 @@ class Project(tmt.EclipseProject):
             gwtUrl = "https://developers.google.com/web-toolkit/download"
             print("You could visit %s and install GWT yourself (be sure to set up a symlink from %s to wherever you installed gwt." % ( gwtUrl, gwtDir ))
             if os.environ.get(INSTALL_GWT_ENV_VAR) or yesNoPrompt("Would you like me to download GWT and extract it to %s for you?" % gwtDir):
-                gwtZipUrl = "http://google-web-toolkit.googlecode.com/files/gwt-2.5.1.zip"
+                gwtZipUrl = "https://storage.googleapis.com/gwt-releases/gwt-2.5.1.zip"
                 dledZipFile = dl(gwtZipUrl)
                 gwtZip = zipfile.ZipFile(dledZipFile)
                 gwtZip.extractall(path=dirname(gwtDir))

--- a/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleHandler.java
+++ b/webscrambles/src/net/gnehzr/tnoodle/server/webscrambles/ScrambleHandler.java
@@ -1,19 +1,17 @@
 package net.gnehzr.tnoodle.server.webscrambles;
 
-import static net.gnehzr.tnoodle.utils.GsonUtils.GSON;
+import com.itextpdf.text.DocumentException;
+import net.gnehzr.tnoodle.server.SafeHttpServlet;
+import net.lingala.zip4j.exception.ZipException;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Date;
 import java.util.LinkedHashMap;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import net.gnehzr.tnoodle.server.SafeHttpServlet;
-import net.lingala.zip4j.exception.ZipException;
-
-import com.itextpdf.text.DocumentException;
+import static net.gnehzr.tnoodle.utils.GsonUtils.GSON;
 
 @SuppressWarnings("serial")
 public class ScrambleHandler extends SafeHttpServlet {
@@ -39,11 +37,6 @@ public class ScrambleHandler extends SafeHttpServlet {
             }
             globalTitle = path[0].substring(0, lastDot);
             ext = path[0].substring(lastDot+1);
-
-            // Chrome seems to be caching scramble requests. These headers unfortunately
-            // don't seem to prevent that behavior.
-            response.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
-            response.setHeader("Pragma", "no-cache");
 
             if(ext == null || ext.equals("txt")) {
                 // Note that we parse the scramble requests *after* checking the extension.

--- a/winstone/src/javax/servlet/http/HttpServlet.java
+++ b/winstone/src/javax/servlet/http/HttpServlet.java
@@ -6,16 +6,15 @@
  */
 package javax.servlet.http;
 
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
-
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 
 /**
  * Base class for http servlets
@@ -103,14 +102,15 @@ public abstract class HttpServlet extends javax.servlet.GenericServlet
             if (lastModified == -1)
                 doGet(request, response);
             else {
-                long ifModifiedSince = request.getDateHeader(HEADER_IFMODSINCE);
-                if (ifModifiedSince < (lastModified / 1000 * 1000)) {
-                    if (!response.containsHeader(HEADER_LASTMOD)
-                            && (lastModified >= 0))
-                        response.setDateHeader(HEADER_LASTMOD, lastModified);
+                // Disabled returning 304 statuses to fix https://github.com/cubing/tnoodle/issues/215
+//                long ifModifiedSince = request.getDateHeader(HEADER_IFMODSINCE);
+//                if (ifModifiedSince < (lastModified / 1000 * 1000)) {
+//                    if (!response.containsHeader(HEADER_LASTMOD)
+//                            && (lastModified >= 0))
+//                        response.setDateHeader(HEADER_LASTMOD, lastModified);
                     doGet(request, response);
-                } else
-                    response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+//                } else
+//                    response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
             }
         } else if (method.equals(METHOD_HEAD)) {
             long lastModified = getLastModified(request);

--- a/winstone/src/net/gnehzr/tnoodle/server/AggressiveHttpListener.java
+++ b/winstone/src/net/gnehzr/tnoodle/server/AggressiveHttpListener.java
@@ -1,12 +1,12 @@
 package net.gnehzr.tnoodle.server;
 
-import java.io.IOException;
-import java.net.ServerSocket;
-import java.util.Map;
-
 import winstone.HostGroup;
 import winstone.HttpListener;
 import winstone.ObjectPool;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.Map;
 
 public class AggressiveHttpListener extends HttpListener {
     public static ServerSocket ss;

--- a/winstone/src/winstone/HttpListener.java
+++ b/winstone/src/winstone/HttpListener.java
@@ -193,6 +193,9 @@ public class HttpListener implements Listener, Runnable {
         // must be the first header. Ajp13 listener can defer to the Apache Server
         // header
         rsp.setHeader("Server", Launcher.RESOURCES.getString("ServerVersion"));
+        rsp.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+        rsp.setHeader("Pragma", "no-cache");
+        rsp.setHeader("Expires", "0");
     }
 
     /**

--- a/winstone/src/winstone/StaticResourceServlet.java
+++ b/winstone/src/winstone/StaticResourceServlet.java
@@ -6,6 +6,11 @@
  */
 package winstone;
 
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -21,12 +26,6 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.StringTokenizer;
-
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 /**
  * Servlet to handle static resources. Simply finds and sends them, or
@@ -130,18 +129,19 @@ public class StaticResourceServlet extends HttpServlet {
                 response.sendRedirect(this.prefix + path + "/");
         }
 
+        // Disabled returning 304 statuses to fix https://github.com/cubing/tnoodle/issues/215
         // Send a 304 if not modified
-        else if (!isInclude && (cachedResDate != -1)
-                && (cachedResDate < (System.currentTimeMillis() / 1000L * 1000L))
-                && (cachedResDate >= (res.lastModified() / 1000L * 1000L))) {
-            String mimeType = getServletContext().getMimeType(
-                    res.getName().toLowerCase());
-            if (mimeType != null)
-                response.setContentType(mimeType);
-            response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
-            response.setContentLength(0);
-            response.flushBuffer();
-        }
+//        else if (!isInclude && (cachedResDate != -1)
+//                && (cachedResDate < (System.currentTimeMillis() / 1000L * 1000L))
+//                && (cachedResDate >= (res.lastModified() / 1000L * 1000L))) {
+//            String mimeType = getServletContext().getMimeType(
+//                    res.getName().toLowerCase());
+//            if (mimeType != null)
+//                response.setContentType(mimeType);
+//            response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+//            response.setContentLength(0);
+//            response.flushBuffer();
+//        }
 
         // Write out the resource if not range or is included
         else if ((request.getHeader(RANGE_HEADER) == null) || isInclude) {


### PR DESCRIPTION
Appends to the header that winstone uses for it's internal implementation of http server.